### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylama.yml
+++ b/.github/workflows/pylama.yml
@@ -1,5 +1,8 @@
 name: Pylama
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/K0ntr4/anigame_fusion/security/code-scanning/2](https://github.com/K0ntr4/anigame_fusion/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root level of the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only requires read access to the repository contents, the `permissions` block should specify `contents: read`. This change ensures that the workflow operates with the minimum required privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
