### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/K0ntr4/anigame_fusion/security/code-scanning/1](https://github.com/K0ntr4/anigame_fusion/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. Since the workflow only needs to read the repository contents (e.g., to check out code), the minimal required permission is `contents: read`. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
